### PR TITLE
Use ADODB.Stream to read/write files

### DIFF
--- a/import.bas
+++ b/import.bas
@@ -15,9 +15,6 @@ Function get_file_xml(file As String) As String
     Dim FSO
     Set FSO = CreateObject("Scripting.FileSystemObject")
     
-    Const ForReading = 1
-    Const ForWriting = 2
-    
     Dim contents As String
     contents = read_file(get_cell_path() & "\" & file)
     

--- a/import.bas
+++ b/import.bas
@@ -18,9 +18,8 @@ Function get_file_xml(file As String) As String
     Const ForReading = 1
     Const ForWriting = 2
     
-    Set doc = FSO.OpenTextFile(get_cell_path() & "\" & file, ForReading)
-    contents = doc.ReadAll
-    doc.Close
+    Dim contents As String
+    contents = read_file(get_cell_path() & "\" & file)
     
     ' Workaround for a REALLY painful MSXML bug(?)
     ' If an attribute looks like attribute="&apos;text"
@@ -31,10 +30,9 @@ Function get_file_xml(file As String) As String
     
     ' For the icing on the cake: MSXML2.DOMDocument.LoadXML only works with UTF-16!
     ' So just use Load with a temporary file instead of converting the string
+    Dim temp_name As String
     temp_name = FSO.GetTempName()
-    Set doc_output = FSO.CreateTextFile(temp_name)
-    doc_output.Write contents
-    doc_output.Close
+    write_file temp_name, contents
     
     get_file_xml = temp_name
 End Function

--- a/sanitize.bas
+++ b/sanitize.bas
@@ -3,16 +3,9 @@ Sub sanitize_xml(file As String, filename As String)
     ' This function is called at the end of every export, because MSXML's output is suboptimal,
     ' and also litters the text with ellipsis characters.
     ' But we can get it to be consistent with TinyXML.
-
-    Dim FSO
-    Set FSO = CreateObject("Scripting.FileSystemObject")
     
-    Const ForReading = 1
-    Const ForWriting = 2
-    
-    Set doc = FSO.OpenTextFile(filename, ForReading)
-    contents = doc.ReadAll
-    doc.Close
+    Dim contents As String
+    contents = read_file(filename)
     
     ' Add XML header and linebreak before root tag
     contents = "<?xml version=""1.0"" encoding=""UTF-8""?>" & Chr(10) & file_comment(file) & Chr(10) & contents
@@ -44,9 +37,7 @@ Sub sanitize_xml(file As String, filename As String)
     contents = Replace(contents, "'", "&apos;")
     contents = Replace(contents, Chr(13), "") ' Windows carriage return
     
-    Set doc_output = FSO.CreateTextFile(filename)
-    doc_output.Write contents
-    doc_output.Close
+    write_file filename, contents
 End Sub
 
 Function file_comment(file As String) As String

--- a/util.bas
+++ b/util.bas
@@ -24,14 +24,27 @@ Function read_file(file As String) As String
     st.Close
 End Function
 
-Sub write_file(file As String, txt As String)
+Sub write_file(file As String, contents As String)
     Dim st As Object
     Set st = CreateObject("ADODB.Stream")
     
-    st.Type = 2
     st.Charset = "utf-8"
     st.Open
-    st.WriteText txt, 1
+    st.WriteText contents, 0
+    
+    'Strip out UTF-8 BOM
+    'Creates a temporary byte array to store BOM-less data
+    st.Position = 0
+    st.Type = 1
+    st.Position = 3
+    
+    Dim byteData() As Byte
+    byteData = st.Read
+    st.Close
+    
+    ' Write final text
+    st.Open
+    st.Write byteData
     st.SaveToFile file, 2
     st.Close
 End Sub

--- a/util.bas
+++ b/util.bas
@@ -12,6 +12,29 @@ Function ListRow_get(row As ListRow, name As String) As String
     Next col
 End Function
 
+Function read_file(file As String) As String
+    Dim st As Object
+    Set st = CreateObject("ADODB.Stream")
+    
+    st.Type = 2
+    st.Charset = "utf-8"
+    st.Open
+    st.LoadFromFile file
+    read_file = st.ReadText(-1)
+    st.Close
+End Function
+
+Sub write_file(file As String, txt As String)
+    Dim st As Object
+    Set st = CreateObject("ADODB.Stream")
+    
+    st.Type = 2
+    st.Charset = "utf-8"
+    st.Open
+    st.WriteText txt, 1
+    st.SaveToFile file, 2
+    st.Close
+End Sub
 
 ' Just some testing stuff
 


### PR DESCRIPTION
![image](https://github.com/Daaaav/TranslationEditor/assets/45000995/ee79a039-598f-4754-87da-f9b4ad320986)
I was having some encoding issues with current translation editor scripts
After some searching, it looks like FSO is designed to handle UTF-16 files, not UTF-8

This PR changes FSO to ADODB.Stream which supports UTF-8